### PR TITLE
Makes Grobid interruptible

### DIFF
--- a/grobid-core/pom.xml
+++ b/grobid-core/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.grobid</groupId>
 		<artifactId>grobid-parent</artifactId>
-		<version>0.3.7-ai2</version>
+		<version>0.3.8-ai2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
   <artifactId>grobid-core</artifactId>
-	<version>0.3.7-ai2</version>
+	<version>0.3.8-ai2</version>
 	<packaging>jar</packaging>
 	<name>${project.artifactId}</name>
 

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -1190,18 +1190,15 @@ public class BiblioItem {
             return null;
         if (str.length() == 0)
             return null;
-        String cleanedString = "";
-        boolean special = false;
+        StringBuilder cleanedString = new StringBuilder(str.length() * 2);
         for (int index = 0; (index < str.length()); index++) {
             char currentCharacter = str.charAt(index);
-            if ((currentCharacter == '\'') || (currentCharacter == '%') || (currentCharacter == '_')) {
-                special = true;
-                cleanedString += '\\';
-            }
-            cleanedString += currentCharacter;
+            if ((currentCharacter == '\'') || (currentCharacter == '%') || (currentCharacter == '_'))
+                cleanedString.append('\\');
+            cleanedString.append(currentCharacter);
         }
 
-        return cleanedString;
+        return cleanedString.toString();
     }
 
     /**

--- a/grobid-core/src/main/java/org/grobid/core/document/BasicStructureBuilder.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/BasicStructureBuilder.java
@@ -196,7 +196,7 @@ public class BasicStructureBuilder {
 	 * 
      * @param doc a document
      */
-    static public void firstPass(Document doc) {
+    static public void firstPass(Document doc) throws InterruptedException {
         if (doc == null) {
             throw new NullPointerException();
         }
@@ -218,6 +218,9 @@ public class BasicStructureBuilder {
         doc.setTitleMatchNum(false);
         try {
             for (Block block : doc.getBlocks()) {
+                if(Thread.interrupted())
+                    throw new InterruptedException();
+
                 String localText = block.getText().trim();
                 localText = localText.replace("\n", " ");
                 localText = localText.replace("  ", " ");

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -334,7 +334,7 @@ public class Document {
 	 * -> should be moved to the header parser class!
 	 */
     public String getHeaderFeatured(boolean getHeader,
-                                    boolean withRotation) {
+                                    boolean withRotation) throws InterruptedException {
         if (getHeader) {
             // String theHeader = getHeaderZFN(firstPass);
             String theHeader = getHeader();
@@ -602,7 +602,7 @@ public class Document {
      * heuristics to get the header section... 
 	 * -> it is now covered by the CRF segmentation model
 	 */ 
-    public String getHeader() {
+    public String getHeader() throws InterruptedException {
         //if (firstPass)
         BasicStructureBuilder.firstPass(this);
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
@@ -210,7 +210,7 @@ public class CitationParser extends AbstractParser {
      */
     public BiblioItem resultExtraction(String result,
                                        boolean volumePostProcess,
-                                       List<String> tokenizations) {
+                                       List<String> tokenizations) throws InterruptedException {
         BiblioItem biblio = new BiblioItem();
 
         StringTokenizer st = new StringTokenizer(result, "\n");
@@ -224,6 +224,9 @@ public class CitationParser extends AbstractParser {
         // respect to spaces
 
         while (st.hasMoreTokens()) {
+            if(Thread.interrupted())
+                throw new InterruptedException();
+
             boolean addSpace = false;
             String tok = st.nextToken().trim();
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
@@ -390,7 +390,7 @@ public class Engine implements Closeable {
      *         information
      * @throws Exception if sth went wrong
      */
-    public String processHeader(String inputFile, boolean consolidate, BiblioItem result) {
+    public String processHeader(String inputFile, boolean consolidate, BiblioItem result) throws InterruptedException {
         return processHeader(inputFile, consolidate, 0, 2, result);
     }
 
@@ -407,7 +407,7 @@ public class Engine implements Closeable {
      * @return the TEI representation of the extracted bibliographical
      *         information
      */
-    public String processHeader(String inputFile, boolean consolidate, int startPage, int endPage, BiblioItem result) {
+    public String processHeader(String inputFile, boolean consolidate, int startPage, int endPage, BiblioItem result) throws InterruptedException {
         // normally the BiblioItem reference must not be null, but if it is the
         // case, we still continue
         // with a new instance, so that the resulting TEI string is still

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -69,7 +69,7 @@ public class HeaderParser extends AbstractParser {
      * zone.
      */
     public Pair<String, Document> processing2(String pdfInput, boolean consolidate,
-                                              BiblioItem resHeader, int startPage, int endPage) {
+                                              BiblioItem resHeader, int startPage, int endPage) throws InterruptedException {
         DocumentSource documentSource = null;
         try {
             documentSource = DocumentSource.fromPdf(new File(pdfInput), startPage, endPage);
@@ -92,7 +92,7 @@ public class HeaderParser extends AbstractParser {
     /**
      * Header processing after identification of the header blocks with heuristics (old approach)
      */
-    public String processingHeaderBlock(boolean consolidate, Document doc, BiblioItem resHeader) {
+    public String processingHeaderBlock(boolean consolidate, Document doc, BiblioItem resHeader) throws InterruptedException {
         String header;
         if (doc.getBlockDocumentHeaders() == null) {
             header = doc.getHeaderFeatured(true, true);

--- a/grobid-home/pom.xml
+++ b/grobid-home/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
 		<groupId>org.grobid</groupId>
 		<artifactId>grobid-parent</artifactId>
-		<version>0.3.7-ai2</version>
+		<version>0.3.8-ai2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
     <artifactId>grobid-home</artifactId>
-	<version>0.3.7-ai2</version>
+	<version>0.3.8-ai2</version>
 	<name>${project.artifactId}</name>
 
 	<profiles>

--- a/grobid-service/pom.xml
+++ b/grobid-service/pom.xml
@@ -4,14 +4,14 @@
 	<parent>
 		<groupId>org.grobid</groupId>
 		<artifactId>grobid-parent</artifactId>
-		<version>0.3.7-ai2</version>
+		<version>0.3.8-ai2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<groupId>org.grobid</groupId>
 	<artifactId>grobid-service</artifactId>
 	<name>${project.artifactId}</name>
-	<version>0.3.7-ai2</version>
+	<version>0.3.8-ai2</version>
 	<packaging>war</packaging>
 
 	<dependencies>

--- a/grobid-trainer/pom.xml
+++ b/grobid-trainer/pom.xml
@@ -4,20 +4,20 @@
 	<parent>
 		<groupId>org.grobid</groupId>
 		<artifactId>grobid-parent</artifactId>
-		<version>0.3.7-ai2</version>
+		<version>0.3.8-ai2</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
     <artifactId>grobid-trainer</artifactId>
 	<name>${project.artifactId}</name>
-	<version>0.3.7-ai2</version>
+	<version>0.3.8-ai2</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.grobid</groupId>
 			<artifactId>grobid-core</artifactId>
-			<version>0.3.7-ai2</version>
+			<version>0.3.8-ai2</version>
 		</dependency>
 		
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.grobid</groupId>
 	<artifactId>grobid-parent</artifactId>
 	<name>${project.artifactId}</name>
-	<version>0.3.7-ai2</version>
+	<version>0.3.8-ai2</version>
 	<packaging>pom</packaging>
 
     <scm>


### PR DESCRIPTION
I changed the Grobid job in scholar so that it will call `Thread.cancel()` after a timeout, but most of the time, that's ignored by Grobid. This change makes Grobid pay attention to the "interrupted" flag on the current thread, and gives up if the current thread was interrupted. I put this check in two places. Empirically it seems that those two places are the critical ones.

There is also a performance fix here that has a surprisingly large impact.
