### PR TITLE
Add coordinates to TEI paragraphs

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1268,12 +1268,16 @@ public class TEIFormatter {
                 }
                 curDiv.appendChild(note);
             } else if (clusterLabel.equals(TaggingLabels.PARAGRAPH)) {
-                String clusterContent = LayoutTokensUtil.normalizeDehyphenizeText(cluster.concatTokens());
+                List<LayoutToken> tokens = cluster.concatTokens();
+                String clusterContent = LayoutTokensUtil.normalizeDehyphenizeText(tokens);
                 if (isNewParagraph(lastClusterLabel, curParagraph)) {
                     curParagraph = teiElement("p");
                     if (config.isGenerateTeiIds()) {
                         String divID = KeyGen.getKey().substring(0, 7);
                         addXmlId(curParagraph, "_" + divID);
+                    }
+                    if (config.isGenerateTeiCoordinates("p")) {
+                        curParagraph.addAttribute(new Attribute("coords", LayoutTokensUtil.getCoordsString(tokens)));
                     }
                     curDiv.appendChild(curParagraph);
                 }


### PR DESCRIPTION
@kyleclo Turns out we made a fork of Grobid long ago. Last commit was 2016. I tagged that commit with the tag `ai2-fork-2020-01-27` and force reset our master branch to the `0.5.6` release of the `kermitt2/grobid` repo.

This change adds PDF coordinates for extracted paragraphs. The coordinates are actually a set of bounding boxes, roughly one for every line, whose union encompasses the full paragraph.

Tested by building a local Docker container and using the API on my local instance.